### PR TITLE
Make GAlgebra.jl work with GAlgebra v0.4.5

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,5 +3,5 @@ using PyCall;
 try
   pyimport("galgebra")
 catch e
-  run(PyCall.python_cmd(`-m pip install -e galgebra --user`))
+  run(PyCall.python_cmd(`-m pip install galgebra --user`))
 end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,6 +3,5 @@ using PyCall;
 try
   pyimport("galgebra")
 catch e
-  run(PyCall.python_cmd(`-m pip install -e git+https://github.com/pygae/galgebra.git#egg=galgebra --user`))
-  run(PyCall.python_cmd(`-m pip install sympy==1.3 --user`))
+  run(PyCall.python_cmd(`-m pip install -e galgebra --user`))
 end

--- a/src/mv.jl
+++ b/src/mv.jl
@@ -78,7 +78,7 @@ Division.
 
 ``A / B \equiv A B^{-1}``. Only valid when ``B`` has inverse.
 """
-@define_op(Mv, /, __div__)
+@define_op(Mv, /, __truediv__)
 
 @doc raw"""
 Comparisons of equality.
@@ -350,7 +350,7 @@ Odd-grade part.
 @define_rop(Mv, Number, -, __rsub__)
 @define_lop(Mv, Number, *, __mul__)
 @define_rop(Mv, Number, *, __rmul__)
-@define_lop(Mv, Number, /, __div__)
+@define_lop(Mv, Number, /, __truediv__)
 @define_rop(Mv, Number, /, __rdiv__)
 @define_lop(Mv, Number, ==, __eq__)
 @define_lop(Mv, Number, !=, __ne__)


### PR DESCRIPTION
- [x] Install GAlgebra from PyPI instead of Github since GAlgebra v0.4.5 is released
- [x] Stop freezing SymPy to 1.3 since GAlgebra v0.4.5 works with SymPy 1.4 and 1.5
- [x] GAlgebra uses __truediv__ instead of __div__, see pygae/galgebra#161