### PR TITLE
Bump CI: Julia 1.10/1.11, Python 3.12, galgebra 0.6.0, updated Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,20 +18,22 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1.10.2]
+        julia-version: ['1.10', '1.11']
         os: [ubuntu-latest]
-        python-version: ["3.11"]
+        python-version: ["3.12"]
         project: ['GAlgebra']
         architecture: ['x64']
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install galgebra
+        run: pip install galgebra==0.6.0
       - name: Setup julia
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.architecture }}
@@ -47,7 +49,7 @@ jobs:
         run: julia --project=@. -e 'using Pkg; cd(Pkg.dir("GAlgebra")); Pkg.add("Coverage"); using Coverage; LCOV.writefile("coverage-lcov.info", Codecov.process_folder())'
         if: success()
       - name: "Submit coverage"
-        uses: codecov/codecov-action@v1.0.2
+        uses: codecov/codecov-action@v4
         with:
           token: ${{secrets.CODECOV_TOKEN}}
         if: success()


### PR DESCRIPTION
Closes #12

- `julia-version`: `1.10.2` → `['1.10', '1.11']` (latest LTS + next)
- `python-version`: `3.11` → `3.12`
- explicit `pip install galgebra==0.6.0` instead of relying on conda
- `actions/checkout` v3 → v4
- `actions/setup-python` v4 → v5
- `julia-actions/setup-julia` v1 → v2
- `codecov/codecov-action` v1.0.2 → v4