### PR TITLE
Split A.4.35 into two separate @test_broken assertions

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -176,10 +176,11 @@ end
         # Summary
         #
         # - The formulas after XXX are work-in-progress
-        # - The following formulas are skip for now
-        #   - A.4.27
+        # - The following formulas are skipped for now
+        #   - A.4.27 (not yet investigated)
         # - The following formulas are broken for now
-        #   - A.4.{33, 35}
+        #   - A.4.33 (see issue #14, now @test_broken)
+        #   - A.4.35 (see issue #15, split into two @test_broken)
     
         @test v * v == (v * v).scalar()
         @test v * B == v ⋅ B + v ∧ B == v ⨼ B + v ∧ B
@@ -360,8 +361,12 @@ end
     
             Vr = u ∧ v
             @test proj(Vr, B) == B ⨼ Vr * (Vr)⁻¹ == (B ⨼ Vr) ⨼ (Vr)⁻¹                               # A.4.34
-            # TODO this is failing for now
-            @test_broken refl(Vr, B) == B ∧ Vr * (Vr)⁻¹ == (B ∧ Vr) ⨽ (Vr)⁻¹                               # A.4.35
+            # A.4.35: rejection formula (B∧Vr)*Vr⁻¹
+            # refl() in galgebra is a grade-by-grade sandwich Vr*B[r]*Vr⁻¹ (with signs),
+            # not rejection. The original chained equality mixed the two.
+            # Split to diagnose which part fails (see issue #15).
+            @test_broken (B ∧ Vr) * (Vr)⁻¹ == (B ∧ Vr) ⨽ (Vr)⁻¹                              # A.4.35 (rejection)
+            @test_broken refl(Vr, B) == (B ∧ Vr) * (Vr)⁻¹                                    # A.4.35 (refl vs rejection)
     
             # The following tests verified interoperability with numeric and symbolic numbers
             (ex, ey, ez) = V.mv()


### PR DESCRIPTION
Refs #15

The original test had a chained `==` mixing three unrelated things:

```julia
@test_broken refl(Vr, B) == B ∧ Vr * (Vr)⁻¹ == (B ∧ Vr) ⨽ (Vr)⁻¹
```

After reading galgebra's `reflect_in_blade` source:
- `refl(Vr, B)` is a grade-by-grade sandwich: `(-1)^{s(r+1)} * Vr * B[r] * Vr⁻¹` for each grade `r`, where `s = grade(Vr)`. For a grade-2 blade (like `Vr = u∧v` in Cl3), the sign is always `+1`, so it reduces to `Vr * B * Vr⁻¹`.
- `(B ∧ Vr) * Vr⁻¹` is the **rejection** (outer projection onto the complement), a completely different operation.

Split into two `@test_broken` so CI shows which part actually fails:
1. `(B ∧ Vr) * (Vr)⁻¹ == (B ∧ Vr) ⨽ (Vr)⁻¹` — pure rejection formula (A.4.35 as written in the paper)
2. `refl(Vr, B) == (B ∧ Vr) * (Vr)⁻¹` — whether the sandwich equals rejection (likely false in general)