### PR TITLE
Fix A.4.35 rejection identity test

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -179,7 +179,7 @@ end
         # - The following formulas are skip for now
         #   - A.4.27
         # - The following formulas are broken for now
-        #   - A.4.{33, 35}
+        #   - A.4.33
     
         @test v * v == (v * v).scalar()
         @test v * B == v ⋅ B + v ∧ B == v ⨼ B + v ∧ B

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -360,8 +360,7 @@ end
     
             Vr = u ∧ v
             @test proj(Vr, B) == B ⨼ Vr * (Vr)⁻¹ == (B ⨼ Vr) ⨼ (Vr)⁻¹                               # A.4.34
-            # TODO this is failing for now
-            @test_broken refl(Vr, B) == B ∧ Vr * (Vr)⁻¹ == (B ∧ Vr) ⨽ (Vr)⁻¹                               # A.4.35
+            @test (B ∧ Vr) * (Vr)⁻¹ == (B ∧ Vr) ⨽ (Vr)⁻¹                                         # A.4.35
     
             # The following tests verified interoperability with numeric and symbolic numbers
             (ex, ey, ez) = V.mv()


### PR DESCRIPTION
Closes #15.

Appendix A.4.35 of arXiv:1205.5935 states the orthogonal rejection identity

`(B ∧ Aᵣ) * inv(Aᵣ) == (B ∧ Aᵣ) ⨽ inv(Aᵣ)`

Reflection is a separate sandwich transformation, so this removes the incorrect `refl(...)` comparison and promotes the rejection identity to a passing test. It also updates the adjacent broken-test summary.

This replaces the remaining A.4.35 framing in #20.

Verification:
- Julia 1.10.11
- GAlgebra test suite: 1332 passed / 1332 total
- Negative control: the former reflection/rejection comparison evaluates false