### PR TITLE
Test the A.4.27 signed subset expansion

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -176,8 +176,6 @@ end
         # Summary
         #
         # - The formulas after XXX are work-in-progress
-        # - The following formulas are skip for now
-        #   - A.4.27
         # - The following formulas are broken for now
         #   - A.4.{33, 35}
     
@@ -365,7 +363,27 @@ end
     
             # The following tests verified interoperability with numeric and symbolic numbers
             (ex, ey, ez) = V.mv()
-    
+
+            # A.4.27: signed expansion over the 2-element subsets of three vectors.
+            B2 = ex ∧ ey + 2 * (ey ∧ ez)
+            a1 = ex + ey
+            a2 = ey + ez
+            a3 = ez + ex
+            lhs_A427 = B2 ⨼ (a1 ∧ a2 ∧ a3)
+            term12_A427 = (B2 ⨼ (a1 ∧ a2)) * a3
+            term13_A427 = (B2 ⨼ (a1 ∧ a3)) * a2
+            term23_A427 = (B2 ⨼ (a2 ∧ a3)) * a1
+
+            @test lhs_A427 != 0
+            @test term12_A427 != 0
+            @test term13_A427 != 0
+            @test term23_A427 != 0
+            @test lhs_A427 == -4 * ex - 2 * ez
+            @test term12_A427 == -3 * ex - 3 * ez
+            @test term13_A427 == -ey - ez
+            @test term23_A427 == -ex - ey
+            @test lhs_A427 == term12_A427 - term13_A427 + term23_A427
+
             uu = vector(V, [1, 2, 3])
             vv = vector(V, [4, 5, 6])
             ww = vector(V, [5, 6, 7])


### PR DESCRIPTION
Refs #16.

This adds a concrete `Cl3` test for Appendix A.4.27 of arXiv:1205.5935. It uses `B₂ = e₁ ∧ e₂ + 2(e₂ ∧ e₃)`, `a₁ = e₁ + e₂`, `a₂ = e₂ + e₃`, and `a₃ = e₃ + e₁`, then verifies the `+, -, +` two-element-subset expansion for `B₂ ⨼ (a₁ ∧ a₂ ∧ a₃)`.

The left-hand side and all three summands are nonzero, and the test checks their exact components. The required sign pattern is unique for this witness: each of the other seven sign choices produces a different result.

PR #18 adds `@test` to three expressions already present in the suite. This patch covers the separate A.4.27 gap, so the changes are complementary.

Tested with Julia 1.10.11 and Python `galgebra==0.6.0`:

`julia --project=. -e 'using Pkg; Pkg.test()'`

Result: 1,340 passed, 1 pre-existing broken, 1,341 total.