### PR TITLE
Use numeric versors for Spacetime A.4.32 tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -224,10 +224,17 @@ end
                 @test wedge_a₁₋ᵣ == prod_a₁₋ᵣ[r]                                                  # A.4.12
 
                 A₁₋ᵣ = prod_a₁₋ᵣ
+                A₁₋ᵣ_for_A432 = if V == Spacetime
+                    # A fixed numeric versor avoids costly symbolic expansion in Cl(1,3).
+                    components = ([3, 2, 1, 1], [3, 1, 1, 2], [3, 1, 2, 1], [3, 1, 1, 1])
+                    reduce(*, [vector(V, c) for c in components[1:r]])
+                else
+                    A₁₋ᵣ
+                end
 
                 for s ∈ dimV
                     Bs = B[s]
-                    A_Bs_Aǂ = A₁₋ᵣ * Bs * (A₁₋ᵣ)ǂ
+                    A_Bs_Aǂ = A₁₋ᵣ_for_A432 * Bs * (A₁₋ᵣ_for_A432)ǂ
 
                     @test A_Bs_Aǂ == A_Bs_Aǂ[s]                                                                              # A.4.32
                 end


### PR DESCRIPTION
Refs #11.

Issue #11 traces the slow Spacetime test to A.4.32, where symbolic versors, especially the product of four symbolic vectors, are multiplied on both sides of symbolic grade components. This patch keeps the same identity check but uses prefixes of these four numeric vectors in Spacetime:

```text
(3, 2, 1, 1)
(3, 1, 1, 2)
(3, 1, 2, 1)
(3, 1, 1, 1)
```

With the `Cl(1,3)` signature, their squared norms are 3, 3, 3, and 6, and their coefficient matrix has determinant 3. Each vector is invertible, so every prefix product is a valid versor. All 20 combinations of `r = 1:4` and `s = 0:4` produce a nonzero result at grade `s`.

A.4.12, A.4.25, and A.4.26 still use the existing symbolic vectors. A.4.32 also continues to use them for every algebra other than Spacetime. Only the test witness changes; library code is untouched.

Verification with Julia 1.10.11 and Python `galgebra==0.6.0`:

- warmed A.4.32 run: 20 grade checks passed in 0.475 seconds
- mutation check: all 20 adjacent-grade substitutions failed
- full suite: 1,331 passed, with the pre-existing broken A.4.35 test

No dependency or version changes are included.